### PR TITLE
point constellation plot links to landing page

### DIFF
--- a/index.md
+++ b/index.md
@@ -72,13 +72,13 @@ and marmoset data with the marmoset data files.
 ## **ABC Atlas Access Tools**
 * * *
 
-[![Constellation](./assets/images/hmba_bg_group_constellation_on_gray_small.png)](http://35.88.252.188:8080/constellation_plot?taxonomy_name=bg_aligned.for_download.20250507.h5&default=true)
+[![Constellation](./assets/images/hmba_bg_group_constellation_on_gray_small.png)](http://35.88.252.188:8080/)
 
 Documentation and tutorials on how to access and visualize the HMBA basal ganglia consensus taxonomy using ABC Atlas Access Tools.
 * **Notebook Tutorials**
   * [Clusters and annotation](https://alleninstitute.github.io/abc_atlas_access/notebooks/hmba_bg_clustering_analysis_and_annotation.html)
   * [Gene expression analysis](https://alleninstitute.github.io/abc_atlas_access/notebooks/hmba_bg_10X_snRNASeq_tutorial.html)
-* [**Constellation Plot Viewer**](http://35.88.252.188:8080/constellation_plot?taxonomy_name=bg_aligned.for_download.20250507.h5&default=true)
+* [**Constellation Plot Viewer**](http://35.88.252.188:8080/)
 * **References**
   * [Cluster annotation terms](https://alleninstitute.github.io/abc_atlas_access/_static/HMBA-BG-taxonomy-CCN20250428/20250531/Cluster.html)
   * [Abbreviation glossary](https://alleninstitute.github.io/abc_atlas_access/_downloads/d86c2fd08499526ee8055d3d226b284a/abbreviation_list.html)


### PR DESCRIPTION
The links to the constellation plot were broken. They were pointing to a version of the taxonomy before the official color scheme had been decided on. That version of the taxonomy is no longer served by the constellation plot viewer.

For whatever, reason, links directly to the taxonomy no longer seem to work. However, users can go to the constellation plot viewer landing page and pick the taxonomy (there is only one) that they want to view.